### PR TITLE
Fix flaky `test_is_entry_invalid_not_colored`

### DIFF
--- a/tests/unit/tracing/test_trace_manager.py
+++ b/tests/unit/tracing/test_trace_manager.py
@@ -92,8 +92,10 @@ class TestTraceManager(TestCase):
 
         self.assertEqual(entry, "Error: dpid not provided")
 
-    def test_is_entry_invalid_not_colored(self):
+    @patch("napps.amlight.sdntrace.shared.colors.Colors.get_switch_color")
+    def test_is_entry_invalid_not_colored(self, mock_colors):
         """Test if the entry request does not have a valid color."""
+        mock_colors.return_value = {}
         eth = {"dl_vlan": 100}
         dpid = {"dpid": "00:00:00:00:00:00:00:01", "in_port": 1}
         switch = {"switch": dpid, "eth": eth}


### PR DESCRIPTION
Fixes #36 

This is a quick fix for this flaky test case `test_is_entry_invalid_not_colored` that was not mocking an underlying `requests` call, thanks for spotting this @Alopalao
