### PR TITLE
[release] Bumped 2022.3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,24 +5,13 @@ All notable changes to the sdntrace NApp will be documented in this file.
 
 [UNRELEASED] - Under development
 ********************************
-Added
-=====
 
-Changed
-=======
-
-Deprecated
-==========
+[2022.3.0] - 2022-12-15
+***********************
 
 Removed
 =======
 - Removed support for OpenFlow 1.0
-
-Fixed
-=====
-
-Security
-========
 
 [2022.2.1] - 2022-08-15
 ***********************

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "amlight",
   "name": "sdntrace",
   "description": "An OpenFlow Data Path Tracing",
-  "version": "2022.2.1",
+  "version": "2022.3.0",
   "napp_dependencies": ["amlight/coloring", "kytos/of_core"],
   "license": "GPL3.0",
   "tags": ["experimental", "coloring"],


### PR DESCRIPTION
Closes N/A

### Summary

- Bumped 2022.3.0

I'm bumping the version of NApps that can already be bumped, when the time comes, it's just a matter of merging and creating the GitHub release with its `git` tag. 