### PR TITLE
feat: added support to send an untagged Ethernet frame

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,15 @@ All notable changes to the sdntrace NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Added
+=====
+- Added support to send an untagged Ethernet frame
+
+Changed
+=======
+- ``eth`` dict payload is not longer mandatory, if it's not set, it's considered a untagged frame, same behavior as ``sdntrace_cp``.
+
+
 [2022.3.0] - 2022-12-15
 ***********************
 

--- a/tests/unit/tracing/test_trace_entries.py
+++ b/tests/unit/tracing/test_trace_entries.py
@@ -480,7 +480,7 @@ class TestLoadEntries(TestCase):
             entries = {"trace": switch}
             self.trace_entries.load_entries(entries)
 
-    def test_missing_eth(self):
+    def test_invalid_eth(self):
         """key trace/switch is mandatory"""
         with self.assertRaises(ValueError):
             eth = 0
@@ -489,6 +489,14 @@ class TestLoadEntries(TestCase):
             entries = {"trace": switch}
             self.trace_entries.load_entries(entries)
 
+    def test_default_eth(self):
+        """Test default eth"""
+        dpid = {"dpid": "a", "in_port": 1}
+        switch = {"switch": dpid}
+        entries = {"trace": switch}
+        self.trace_entries.load_entries(entries)
+        assert not self.trace_entries.dl_vlan
+
     def test_minimally_correct(self):
         """key trace/switch is mandatory"""
         eth = {"dl_vlan": 100}
@@ -496,3 +504,6 @@ class TestLoadEntries(TestCase):
         switch = {"switch": dpid, "eth": eth}
         entries = {"trace": switch}
         self.trace_entries.load_entries(entries)
+        assert self.trace_entries.dl_vlan == eth["dl_vlan"]
+        assert self.trace_entries.dpid == dpid["dpid"]
+        assert self.trace_entries.in_port == dpid["in_port"]

--- a/tracing/trace_entries.py
+++ b/tracing/trace_entries.py
@@ -19,7 +19,7 @@ class TraceEntries(object):
         self._dl_src = 0
         self._dl_dst = 'ca:fe:ca:fe:ca:fe'
         self._dl_vlan = 0
-        self._dl_type = 2048
+        self._dl_type = 0x800
         self._dl_vlan_pcp = 0
         self._nw_src = '1.1.1.1'
         self._nw_dst = '1.1.1.2'
@@ -320,16 +320,11 @@ class TraceEntries(object):
             self.in_port = switch['in_port']
 
         # Basic entries['trace']['switch']
-        if 'eth' not in trace:
-            raise ValueError("Error: eth not provided")
-        elif not isinstance(trace['eth'], dict):
+        eth = trace.get("eth", {})
+        if not isinstance(eth, dict):
             raise ValueError("Error: eth has to be dict")
 
-        eth = trace['eth']
-
-        if 'dl_vlan' not in eth:
-            raise ValueError("Error: dl_vlan not provided")
-        else:
+        if 'dl_vlan' in eth:
             self.dl_vlan = eth['dl_vlan']
 
         if 'dl_src' in eth:

--- a/tracing/trace_pkt.py
+++ b/tracing/trace_pkt.py
@@ -150,9 +150,10 @@ def _create_ethernet_frame(trace_entries, color):
     ethernet.source = color['color_value']
     ethernet.destination = trace_entries.dl_dst
 
-    vlan = VLAN(vid=trace_entries.dl_vlan,
-                pcp=trace_entries.dl_vlan_pcp)
-    ethernet.vlans.append(vlan)
+    if trace_entries.dl_vlan:
+        vlan = VLAN(vid=trace_entries.dl_vlan,
+                    pcp=trace_entries.dl_vlan_pcp)
+        ethernet.vlans.append(vlan)
     return ethernet
 
 


### PR DESCRIPTION
Closes #16 

### Summary

See updated changelog file

### Local Tests

- I provisioned an `"untagged"` EVC and managed to get a successful trace on `PUT /api/amlight/sdntrace/trace`

```
{
    "trace": {
        "switch": {
            "dpid": "{{dpid}}",
            "in_port": 1
        }
    }
}
```

```
{
    "request_id": 30004,
    "result": [
        {
            "type": "starting",
            "dpid": "00:00:00:00:00:00:00:01",
            "port": 1,
            "time": "2023-06-08 13:58:15.215571"
        },
        {
            "type": "trace",
            "dpid": "00:00:00:00:00:00:00:03",
            "port": 3,
            "time": "0:00:00.522553"
        },
        {
            "type": "last",
            "reason": "done",
            "msg": "none",
            "time": "0:00:02.042512"
        }
    ],
    "start_time": "2023-06-08 13:58:15.215571",
    "total_time": "0:00:02.042919",
    "request": {
        "trace": {
            "switch": {
                "dpid": "00:00:00:00:00:00:00:01",
                "in_port": 1
            }
        }
    }
}
```

Also confirmed on wireshark that the Ethernet frame on PacketOut had a correct eth type:

![20230608_135849](https://github.com/kytos-ng/sdntrace/assets/1010796/ed83f7ac-d09d-486d-a935-28ccd58454fb)

Here's a subsequent step:

![20230608_135901](https://github.com/kytos-ng/sdntrace/assets/1010796/4e50b1b8-5f73-41c4-882f-7257ab326333)


### End-to-End Tests

In progress, it'll be covered on issue #43 
