### PR TITLE
sdntrace ui

### DIFF
--- a/ui/k-info-panel/show_all_traces.kytos
+++ b/ui/k-info-panel/show_all_traces.kytos
@@ -1,0 +1,136 @@
+<template>
+  <div class="sdntrace_container">
+    <k-accordion>
+      <k-accordion-item title="Trace Results">
+        <k-context-panel v-if="is_empty" title="Empty Result" icon="gear">
+          </k-context-panel>
+            <div v-else class="data_table">
+              <table>
+                <thead>
+                  <tr>
+                    <th rowspan="2">Trace ID</th>
+                    <th rowspan="2">DPID</th>
+                    <th rowspan="2">Time</th>
+                    <th rowspan="2">Type</th>
+                    <th rowspan="2">Port</th>               
+                  </tr>
+                </thead>
+                <tbody>
+                  <template v-for="(item, index) in trace_results">
+                    <tr v-for="(results_item, results_index) in item.result" :key="results_index">
+                      <td>{{ item.request_id }}</td>
+                      <td>{{ results_item.dpid }}</td>
+                      <td>{{ results_item.time }}</td>
+                      <td>{{ results_item.type }}</td>
+                      <td>{{ results_item.port }}</td>
+                    </tr>
+                    <div>
+                      <k-button icon="search" title="View" :on_click="() => view_trace(item.request_id)"></k-button>
+                    </div>
+                  </template>
+                </tbody>
+            </table>
+          </div>
+        </k-accordion-item>
+        <k-accordion>          
+       
+        </k-accordion>
+    </k-accordion>
+  </div>
+</template>
+
+<script>
+ module.exports = {
+   props: ["content"],
+   methods: {
+    get_data(){
+      if (this.content != undefined && this.content != "")
+      {
+        if (this.content != "")
+        {
+          this.is_empty = false
+          this.trace_results = this.content
+          
+        } else {
+          this.is_empty = true
+        }
+      }
+    },
+    
+    view_trace (id) {
+      var content = {
+        "component": 'amlight-sdntrace-k-info-panel-show_trace_results',
+        "content": id,
+        "icon": "search-location",
+        "title": "Trace",
+        "subtitle": "by amlight/sdntrace"
+      }
+      this.$kytos.$emit("showInfoPanel", content)
+    } 
+  },
+  watch: {
+    content: function() {
+      this.get_data();
+    }
+  },
+  created() {
+    this.get_data();
+    $('.k-info-panel:has(.sdntrace_container)').addClass('sdntrace-k-info-panel');
+  },
+  mounted() {
+    this.$parent.$el.style.width = "calc(100% - 300px)";
+  },
+  destroyed() {
+    $('.k-info-panel').removeClass('sdntrace_container-k-info-panel');
+  },
+   data () {
+     return {
+      trace_results: {},
+      is_empty: false,
+      traceId: ""
+     }
+   }
+ }
+</script>
+<style>
+.sdntrace-k-info-panel {
+  width: calc(100% - 300px);
+}
+.data_table {
+  color: #ccc;
+  max-height: 250px;
+  text-align: center;
+  margin: 0 auto;
+  display: block;
+  padding: 0.5em 0 1em 0.3em;
+  font-size: 0.8em;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+.data_table table{
+  display: table;
+  width: 100%;
+}
+.data_table thead{
+  font-weight: bold;
+  background: #554077;
+}
+.data_table th{
+  padding: 0.6em 0 0.6em 0;
+  vertical-align: middle;
+  border: 1px solid;
+}
+.data_table td{
+  vertical-align: middle;
+  padding: 0.45em 0 0.45em 0;
+  word-break: break-all;
+  border: 1px solid;
+}
+.data_table tbody tr:nth-child(even) {
+  background: #313131;
+}
+.data_table tbody tr:hover {
+  color: #eee;
+  background-color: #666;
+}
+</style>

--- a/ui/k-info-panel/show_trace_results.kytos
+++ b/ui/k-info-panel/show_trace_results.kytos
@@ -1,0 +1,183 @@
+<template>
+  <div class="sdntrace_container">
+    <k-accordion>
+      <k-accordion-item title="Single Trace">
+        <k-context-panel v-if="is_empty" title="Empty Result" icon="gear">
+          </k-context-panel>
+            <div v-else class="data_table">
+              <table>
+                <thead>
+                  <tr>
+                    <th rowspan="2">Trace ID</th>
+                    <th rowspan="2">DPID</th>
+                    <th rowspan="2">Time</th>
+                    <th rowspan="2">Type</th>
+                    <th rowspan="2">Port</th>
+                </thead>
+                <tbody>
+                  <tr v-for="(item, index) in trace_results">
+                    <td>{{traceId}}</td>
+                    <td>{{item.dpid}}</td>
+                    <td>{{item.time}}</td>
+                    <td>{{item.type}}</td>
+                    <td>{{item.port}}</td>             
+                  </tr>
+                </tbody>
+            </table>
+          </div>
+        </k-accordion-item>
+        <k-accordion>          
+          <div>
+          <k-button icon="search" title="Fetch Trace" :on_click="fetchTrace"></k-button>
+          </div>
+        </k-accordion>
+        <k-accordion>          
+          <div>
+          <k-button icon="search" title="View All Traces" :on_click="get_all_traces"></k-button>
+          </div>
+        </k-accordion>
+    </k-accordion>
+  </div>
+</template>
+
+<script>
+ module.exports = {
+   props: ["content"],
+   methods: {
+    fetchTrace() {
+        var self = this;
+        $.ajax({
+            async: true,
+            dataType: "json",
+            type: "GET", 
+            url: `${this.$kytos_server_api}amlight/sdntrace/trace/${this.content}`,
+            success: function(response) {
+            self.trace_results = response.result; 
+            self.traceId = response.request_id;
+            self.is_empty = !self.trace_results.length; 
+            },
+            error: function() { 
+              self.is_empty = true;
+              self.trace_results = [];
+            }
+        });
+   },
+   
+ 
+    get_all_traces () {
+      var self = this
+      self.get_topology()
+
+      let request = $.ajax({
+        async: true,
+        dataType: "json",
+        type: "GET",
+        contentType: "application/json",
+        url: this.$kytos_server_api + "amlight/sdntrace/trace",
+      });
+
+      request.done(function(data) {
+        self.trace = data;
+        self.show_traces();
+      });
+
+      request.fail(function(data) {
+        let notification = {
+          icon: 'gear',
+          title: 'Bad request',
+          description: data.status + ': ' + data.responseJSON.description
+        };
+        self.$kytos.$emit("setNotification", notification);
+      });
+    },
+    
+    show_traces() {
+      var content = {
+        "component": 'amlight-sdntrace-k-info-panel-show_all_traces',
+        "content": this.trace,
+        "icon": "map-marker",
+        "title": "Trace",
+        "subtitle": "by amlight/sdntrace"
+      }
+      this.$kytos.$emit("showInfoPanel", content)
+    },
+    
+    get_topology(){
+      var self = this
+      $.ajax({
+        async: true,
+        dataType: "json",
+        url: this.$kytos_server_api + "kytos/topology/v3",
+
+        success: function(data) {
+          self.switches = data['topology']['switches']
+          self.links = data['topology']['links']
+        }
+      });
+    } 
+  },
+  watch: {
+    content: function() {
+    }
+  },
+  created() {
+    $('.k-info-panel:has(.sdntrace_container)').addClass('sdntrace-k-info-panel');
+  },
+  mounted() {
+    this.$parent.$el.style.width = "calc(100% - 300px)";
+  },
+  destroyed() {
+    $('.k-info-panel').removeClass('sdntrace_container-k-info-panel');
+  },
+   data () {
+     return {
+      trace_results: {},
+      is_empty: false,
+      traceId: "",
+      trace: {}
+     }
+   }
+ }
+</script>
+<style>
+.sdntrace-k-info-panel {
+  width: calc(100% - 300px);
+}
+.data_table {
+  color: #ccc;
+  max-height: 250px;
+  text-align: center;
+  margin: 0 auto;
+  display: block;
+  padding: 0.5em 0 1em 0.3em;
+  font-size: 0.8em;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+.data_table table{
+  display: table;
+  width: 100%;
+}
+.data_table thead{
+  font-weight: bold;
+  background: #554077;
+}
+.data_table th{
+  padding: 0.6em 0 0.6em 0;
+  vertical-align: middle;
+  border: 1px solid;
+}
+.data_table td{
+  vertical-align: middle;
+  padding: 0.45em 0 0.45em 0;
+  word-break: break-all;
+  border: 1px solid;
+}
+.data_table tbody tr:nth-child(even) {
+  background: #313131;
+}
+.data_table tbody tr:hover {
+  color: #eee;
+  background-color: #666;
+}
+</style>

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -1,0 +1,281 @@
+<template>
+  <k-toolbar-item icon="map-marker" tooltip="Napp sdntrace">
+    <div class="scroll">
+      <k-accordion>
+        <k-accordion-item title="Trace">
+        
+          <k-accordion-item title="Required Switch Parameters">
+          
+            <k-input-auto id="dpid" :value.sync="dpid"
+                          title="DPID:"
+                          placeholder="DPID" icon="arrow-right"
+                          :candidates="dpids"
+                          @focus="get_dpids"
+                          @blur="onblur_dpids"
+                          >{{ dpid }}
+            </k-input-auto>
+            
+            <k-input class="k-input interface-label" :value.sync="dpid_display" icon="none"
+                      >{{ dpid_display }}</k-input>
+            
+            <k-input-auto id="in_port" :value.sync="in_port"
+                          title="Port:"
+                          placeholder="Port" icon="arrow-right"
+                          :candidates="port_numbers"
+                          @focus="get_ports"
+                          @blur="onblur_ports"
+                      >{{ in_port }}
+            </k-input-auto>
+            
+            <k-input class="k-input interface-label" :value.sync="port_name" icon="none"
+                      >{{ port_name }}</k-input>
+
+            
+          </k-accordion-item>
+
+          <k-accordion-item title="Eth Parameters">
+            <k-input icon="arrow-right" title="dl_vlan:" placeholder="dl_vlan" :value.sync="eth.dl_vlan">{{ eth.dl_vlan }}</k-input>
+            <k-input icon="arrow-right" title="dl_type:" placeholder="dl_type" :value.sync="eth.dl_type">{{ eth.dl_type }}</k-input>
+            <k-input icon="arrow-right" title="dl_src:" placeholder="dl_src" :value.sync="eth.dl_src">{{ eth.dl_src }}</k-input>
+            <k-input icon="arrow-right" title="dl_dst:" placeholder="dl_dst" :value.sync="eth.dl_dst" >{{ eth.dl_dst }}</k-input>
+          </k-accordion-item>
+          
+          <k-accordion-item title="IP Parameters">
+            <k-accordion-item title="IPV4">
+              <k-input icon="arrow-right" title="nw_src:" placeholder="nw_src" :value.sync="ip.nw_src">{{ ip.nw_src }}</k-input>
+              <k-input icon="arrow-right" title="nw_dst:" placeholder="nw_dst" :value.sync="ip.nw_dst">{{ ip.nw_dst }}</k-input>
+            </k-accordion-item>
+
+            <k-accordion-item title="IPV6">
+              <k-input icon="arrow-right" title="ipv6_src:" placeholder="ipv6_src" :value.sync="ip.ipv6_src">{{ ip.ipv6_src }}</k-input>
+              <k-input icon="arrow-right" title="ipv6_dst:" placeholder="ipv6_dst" :value.sync="ip.ipv6_dst">{{ ip.ipv6_dst }}</k-input>
+            </k-accordion-item>
+            <k-accordion>
+              <k-input icon="arrow-right" title="nw_proto:" placeholder="nw_proto" :value.sync="ip.nw_proto">{{ ip.nw_proto }}</k-input>
+              <k-input icon="arrow-right" title="nw_tos:" placeholder="nw_tos" :value.sync="ip.nw_tos">{{ ip.nw_tos }}</k-input>
+
+          </k-accordion-item>
+
+          <div >
+            <k-button icon="search" title="Start Trace" :on_click="start_trace">
+            </k-button>
+          </div>
+
+          <div>
+            <k-button icon="eraser" title="Reset" :on_click="reset_inputs">
+            </k-button>
+          </div>
+          
+          </k-accordion-item>
+          
+      </k-accordion>
+    </div>
+  </k-toolbar-item>
+</template>
+
+
+<script>
+module.exports = {
+  methods: {
+    start_trace() {
+      var self = this
+      self.get_topology()
+      var payload = {
+          trace: {
+              switch: {
+                  dpid: self.dpid,
+                  in_port: parseInt(self.in_port) || ""
+              },
+              eth: {
+                "dl_vlan": parseInt(self.eth.dl_vlan) || "",
+                "dl_type": parseInt(self.eth.dl_type) || "",
+                "dl_src": self.eth.dl_src,
+                "dl_dst": self.eth.dl_dst
+              },
+              ip: {
+                     "nw_src": self.ip.nw_src,
+                     "nw_dst": self.ip.nw_dst,
+                     "ipv6_src": self.ip.ipv6_src,
+                     "ipv6_dst": self.ip.ipv6_dst,
+                     "nw_proto": parseInt(self.ip.nw_proto) || "",
+                     "nw_tos": parseInt(self.ip.nw_tos) || ""
+                   }
+            }
+          }
+          
+           payload.trace.eth = Object.fromEntries(Object.entries(payload.trace.eth).filter(function ([k, v]) {
+                                                                                        return (v != "");
+                                                                                        }));
+           payload.trace.ip = Object.fromEntries(Object.entries(payload.trace.ip).filter(function ([k, v]) {
+                                                                                        return (v != "");
+                                                                                        }));      
+           
+             let request= $.ajax({
+              async: true,
+              dataType: "json",
+              type: "PUT",
+              contentType: "application/json",
+              data: JSON.stringify(payload),
+              url: this.$kytos_server_api + "amlight/sdntrace/trace",
+             }); 
+             
+
+      request.done(function(data) {
+        if (data.result.trace_id != "" && data.result.trace_id) { 
+           self.traceId = data.result.trace_id;
+           self.show(); 
+        };
+      });
+           
+   
+       request.fail(function(data) {
+        let notification = {
+          icon: 'gear',
+          title: ' Bad request',
+          description: data.status + ': ' + data.responseJSON.description
+        };
+        self.$kytos.$emit("setNotification", notification);
+      });
+      
+    },
+    
+       
+    show() {
+      var content = {
+                    "component": 'amlight-sdntrace-k-info-panel-show_trace_results',
+                    "content": this.traceId,
+                    "icon": "map-marker",
+                    "title": "Trace",
+                    "subtitle": `by amlight/sdntrace`
+                    }
+      this.$kytos.$emit("showInfoPanel", content)
+      },
+      
+    
+      get_topology(){
+      var self = this
+      $.ajax({
+        async: true,
+        dataType: "json",
+        url: this.$kytos_server_api + "kytos/topology/v3",
+
+        success: function(data) {
+          self.switches = data['topology']['switches']
+          self.links = data['topology']['links']
+        }
+      });
+    },
+    
+       reset_inputs() {
+            this.dpid = ""
+            this.in_port = ""
+            this.eth.dl_vlan = ""
+            this.eth.dl_type = ""
+            this.eth.dl_src = ""
+            this.eth.dl_dst = ""
+            this.ip.nw_src = ""
+            this.ip.nw_dst = ""
+            this.ip.ipv6_src = ""
+            this.ip.ipv6_dst = ""
+            this.ip.nw_proto = ""
+            this.ip.nw_tos = "" 
+            this.traceId = "" 
+        }
+},
+    computed: {
+      get_dpids(){
+        var dpids = []
+        $.each(this.switches, function(key, value){
+          if (value.metadata.node_name != undefined && value.metadata.node_name != "") {
+            dpids.push(`${value.metadata.node_name} - ${value.dpid}`)
+          } else if (value.data_path != "None") {
+            dpids.push(`${value.data_path} - ${value.dpid}`)
+          } else {
+            dpids.push(value.dpid)
+          }
+        });
+        this.dpids = dpids; 
+      },
+      
+      get_ports(){
+        current_dpid = this.dpid
+        current_switch = this.switches[current_dpid]
+        var port_numbers = []
+        if (current_switch != undefined && current_switch != "") {
+          $.each(current_switch.interfaces, function(key, value) {
+            if (value.metadata.port_name != undefined && value.metadata.port_name != "") {
+              port_numbers.push(`${value.metadata.port_name} - ${value.port_number}`)
+            } else {
+              port_numbers.push(`${value.name} - ${value.port_number}`)
+            }
+          });
+        } else {
+          port_numbers.push("No DPID Choosen")
+        }
+        this.port_numbers = port_numbers;
+      },
+      
+      onblur_dpids(){
+        let current_dpid = this.dpid
+        if (current_dpid.lastIndexOf(' ') > 0) {
+          this.dpid_display = current_dpid
+          let splitted_dpid = current_dpid.split(' ')
+          this.dpid = splitted_dpid[splitted_dpid.length - 1]
+          let current_switch = this.switches[this.dpid]
+        }
+        this.dpid_display = current_dpid
+        this.port_name = ""
+        this.in_port = ""
+      },
+      onblur_ports(){
+        let current_port = this.in_port
+        if (current_port.lastIndexOf(' ') > 0) {
+          let splitted_port = current_port.split(' ')
+          this.in_port = splitted_port[splitted_port.length-1]
+          this.port_name = splitted_port[0]
+        }
+      }
+    },
+    created(){
+      this.get_topology();
+    },
+    data: function() {
+        return {
+            trace: {},
+            switches: [],
+            traceId: '',
+            dpid: "",
+            dpids: [],
+            in_port: "",
+            port_numbers: [],
+            port_name: "",
+            dpid_display: "",
+            eth: {
+              "dl_vlan": "",
+              "dl_type": "",
+              "dl_src": "",
+              "dl_dst": ""
+              },
+           ip: {
+                "nw_src": "",
+                "nw_dst": "",
+                "ipv6_src":"",
+                "ipv6_dst": "",
+                "nw_proto": "",
+                "nw_tos": ""
+            }
+        }
+     }
+   }
+</script>
+
+
+<style>
+  .autocomplete-result-list li {
+    white-space: nowrap;
+    margin-right: 100% !important;
+    outline: 50;
+    border: 1px #515151 solid;
+    border-radius: 3px;
+  }
+</style>


### PR DESCRIPTION
Closes #6
Closes #7
Closes #8

### Summary

Created ‘ui’ folder and all the programs for the ui of sdntrace napp to work

### Local Tests

![kytos3](https://github.com/kytos-ng/sdntrace/assets/32799214/778f4baf-7945-4134-9a68-7a97d4e8fad3)
![kytos2](https://github.com/kytos-ng/sdntrace/assets/32799214/e7fdc688-69c1-4313-81f6-748ae9724bd6)
![kytos1](https://github.com/kytos-ng/sdntrace/assets/32799214/cc38cf00-d24f-4f81-b05f-5f3605d96f6a)

### End-to-End Tests
