### PR TITLE
Migration to Vue3: additional change to make InfoPanel display maximized as before

### DIFF
--- a/ui/k-info-panel/show_all_traces.kytos
+++ b/ui/k-info-panel/show_all_traces.kytos
@@ -58,6 +58,7 @@
         "component": 'amlight-sdntrace-k-info-panel-show_trace_results',
         "content": trace,
         "icon": "map-marker",
+        "maximized": true,
         "title": "Trace",
         "subtitle": "by amlight/sdntrace"
       }

--- a/ui/k-info-panel/show_trace_results.kytos
+++ b/ui/k-info-panel/show_trace_results.kytos
@@ -114,6 +114,7 @@
         "component": 'amlight-sdntrace-k-info-panel-show_all_traces',
         "content": this.trace,
         "icon": "map-marker",
+        "maximized": true,
         "title": "Trace",
         "subtitle": "by amlight/sdntrace"
       }

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -187,6 +187,7 @@ module.exports = {
         "component": 'amlight-sdntrace-k-info-panel-show_all_traces',
         "content": this.trace,
         "icon": "map-marker",
+        "maximized": true,
         "title": "Trace",
         "subtitle": "by amlight/sdntrace"
       }
@@ -199,6 +200,7 @@ module.exports = {
           "component": 'amlight-sdntrace-k-info-panel-show_trace_results',
           "content": this.traceId,
           "icon": "map-marker",
+          "maximized": true,
           "title": "Trace",
           "subtitle": `by amlight/sdntrace`
       }


### PR DESCRIPTION
Related to https://github.com/kytos-ng/ui/issues/35

### Summary

This PR should sit on top of https://github.com/kytos-ng/sdntrace_cp/pull/116 and it makes the InfoPanel be displayed maximized as it used to be before vue3 migration