### PR TITLE
Added TCP and UDP support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,7 @@ Changed
 
 Added
 =====
-
+- Added support for TCP and UDP protocols.
 - Added UI components to send a request, display a single trace, and display all traces.
 
 [2023.1.0] - 2023-06-06

--- a/openapi.yml
+++ b/openapi.yml
@@ -212,9 +212,9 @@ components:
         nw_tos:
           type: integer
           format: int32
-        # nw_proto: # Future release
-        #   type: integer
-        #   format: int32
+        nw_proto:
+          type: integer
+          format: int32
     TransactionProgram: # Can be referenced via '#/components/schemas/TransactionProgram'
       type: object
       properties:

--- a/shared/extd_nw_types.py
+++ b/shared/extd_nw_types.py
@@ -3,21 +3,257 @@
 Defines and Implements Basic Network packet types, such as TCP and UDP.
 """
 
+from pyof.foundation.network_types import IPv4, IPv6
 from pyof.foundation.base import GenericStruct
-# from pyof.foundation.basic_types import (BinaryData, UBInt16)
-
+from pyof.foundation.basic_types import BinaryData, UBInt16, UBInt32
+from typing import Union
+from random import randrange
 
 __all__ = ('TCP', 'UDP')
 
 
 class TCP(GenericStruct):
-    """TCP - To be developed """
-    def __init__(self):
-        pass
+    """TCP - Being developed """
+
+    source_p = UBInt16()
+    destination_p = UBInt16()
+    sequence_n = UBInt32()
+    acknowledgment_n = UBInt32()
+    _length_flags = UBInt16()
+    window = UBInt16()
+    checksum = UBInt16()
+    urgent_pointer = UBInt16()
+    options = BinaryData()
+    data = BinaryData()
+
+    def __init__(self, source_p:int=0, destination_p:int=0, sequence_n:int=0, acknowledgment_n:int=0, h_length:int=5,
+                 flags:int=2, window:int=0, checksum:int=0, urgent_pointer:int=0, options:bytes=b'', data:bytes=b''):
+        """
+        These default values are considering this TCP message is first sent, initiating
+         handshake.
+
+        Args:
+            source_p(int): Source port. Defaults to 0
+            destination_p(int): Destination port. Defaults to 0
+            sequence_n(int): Sequence number (raw). Random number [0, 4294967296]
+            acknowledgment_n(int): Acknowledgment number (raw). Defaults to 0
+            h_length(int): Header length, data offset. Defaults(minimun) to 5 words
+            flags(bits): Flags. Defaults to 2 or 0000 0000 0010. Divided in:
+                reserved: Reserved, not used yet. Defaults to 000
+                ecn_acc: Accurate ECN. Defaults to 0
+                cwr: Congestion window reduced. Defaults to 0
+                ecn_echo: ECN-Echo. Defaults to 0
+                urgent: Urgent. Defaults to 0
+                ack: Acknoledgment. Defaults to 0
+                push: Push. Defaults to 0
+                reset: Reset. Defaults to 0
+                syn: Syn. Defaults to 1
+                fin: Fin. Defaults to 0
+            window(int): Window. Defaults to 43690
+            checksum(int): Checksum. Defaults to 0
+            urgent_pointer(int): Urgent pointer. Defaults to 0
+            options(bytes): Options. Defaults to empty bytes
+            data(bytes): Data. Defaults to empty bytes
+        """
+        super().__init__()
+        self.source_p = source_p
+        self.destination_p = destination_p
+        self.sequence_n = sequence_n if sequence_n != 0 else randrange(4294967296)
+        self.acknowledgment_n = acknowledgment_n
+        self.h_length = h_length
+        self.flags = flags
+        # window default value (b'\xaa\xaa') is an arbitrary number until advised otherwise.
+        self.window = window
+        self.checksum = checksum
+        self.urgent_pointer = urgent_pointer
+        self.options = options
+        self.data = data
+
+    def _value_by_half_word(self, value: bytes) -> int:
+        """Calculate the integer value of the argument partitioned by 2 bytes."""
+        total = 0
+        while value:
+            total = total + int.from_bytes(value[-2:])
+            value = value[:-2]
+        return total
+
+    def _update_checksum(self, ip_header: Union[IPv4, IPv6]):
+        """Update the packet checksum to enable integrity check.
+         Each addend is 16 bits."""
+        # TODO: Overflown data in practice (91 bytes).
+        #       Lenght currently is not accurate
+        # self.h_length = 5 + (len(self.options) // 4) + (len(self.data) // 4)
+        self.h_length = 5 + (len(self.options) // 4) + 0
+        self._length_flags = self.h_length << 12 | self.flags
+
+        sequence_hex = hex(self.sequence_n)[2:]
+        acknowledgment_hex = hex(self.acknowledgment_n)[2:]
+        sequence_upper = int(sequence_hex[:4] or '0', 16)
+        sequence_lower = int(sequence_hex[-4:] or '0', 16)
+        acknowledgment_upper = int(acknowledgment_hex[:4] or '0', 16)
+        acknowledgment_lower = int(acknowledgment_hex[-4:] or '0', 16)
+
+        if isinstance(ip_header, IPv4):
+            source_list = [int(octet) for octet in ip_header.source.split(".")]
+            destination_list = [int(octet) for octet in
+                                ip_header.destination.split(".")]
+            source_upper = (source_list[0] << 8) + source_list[1]
+            source_lower = (source_list[2] << 8) + source_list[3]
+            destination_upper = (destination_list[0] << 8) + destination_list[1]
+            destination_lower = (destination_list[2] << 8) + destination_list[3]
+            ip_value = (source_upper + source_lower + destination_upper +
+                        destination_lower + ip_header.protocol + (self.h_length * 4))
+        else:
+            # TODO: Implement IPv6 header analysis
+            ip_value = 0
+
+        block_sum = (self.source_p + self.destination_p + sequence_upper +
+                         sequence_lower + acknowledgment_upper + acknowledgment_lower +
+                         self._length_flags + self.window + 0 + self.urgent_pointer +
+                         self._value_by_half_word(self.options) +
+                         self._value_by_half_word(self.data) + ip_value)
+        
+        while block_sum > 65535:
+            carry = block_sum >> 16
+            block_sum = (block_sum & 65535) + carry
+
+        self.checksum = ~block_sum & 65535
+
+    def pack(self, ip_header: Union[IPv4, IPv6], value=None):
+        """Pack the struct in a binary representation.
+
+        Merge some fields to ensure correct packing.
+
+        Returns:
+            bytes: Binary representation of this instance.
+
+        """
+        self._update_checksum(ip_header)
+        return super().pack(value)
+    
+    def unpack(self, buff:bytes, offset=0):
+        """Unpack a binary struct into this object's attributes.
+
+        Return the values instead of the lib's basic types.
+
+        Args:
+            buff (bytes): Binary buffer.
+            offset (int): Where to begin unpacking.
+
+        Raises:
+            :exc:`~.exceptions.UnpackException`: If unpack fails.
+
+        """
+        super().unpack(buff, offset)
+        self.source_p = self.source_p.value
+        self.destination_p = self.destination_p.value
+        self.sequence_n = self.sequence_n.value
+        self.acknowledgment_n = self.acknowledgment_n.value
+        self.h_length = self._length_flags.value >> 12
+        self.flags = self._length_flags.value & 4095
+        self.window = self.window.value
+        self.checksum = self.checksum.value
+
+        if self.h_length > 5:
+            option_size = (self.h_length - 5) * 4
+            self.data = self.options.value[option_size:]
+            self.options = self.options.value[:option_size]
+        else:
+            self.data = self.options.value
+            self.options = b''
 
 
 class UDP(GenericStruct):
-    """ UDP - To be developed """
+    """ UDP - Being developed """
 
-    def __init__(self):
-        pass
+    source_p = UBInt16()
+    destination_p = UBInt16()
+    length = UBInt16()
+    checksum = UBInt16()
+    data = BinaryData()
+    
+    def __init__(self, source_p:int=0, destination_p:int=0, length:int=0, checksum:int=0, data:bytes=b''):
+        """Create an UDP header with default values.
+
+        Args:
+            source_p(int): Source port. Defaults to 0
+            destination_p(int): Destination port. Defaults to 0
+            length(int): Length. Defaults to 8 (minimum in bytes)
+            checksum(int): Checksum. Defaults to 0
+            data(bytes): Data. Defults to empty bytes
+
+        """
+        self.source_p = source_p
+        self.destination_p = destination_p
+        self.length = length
+        self.checksum = checksum
+        self.data = data
+
+    def _value_by_16_bits(self, value: bytes) -> int:
+        """Calculate the integer value of the argument partitioned by 2 bytes."""
+        total = 0
+        while value:
+            total = total + int.from_bytes(value[-2:])
+            value = value[:-2]
+        return total
+
+    def _update_checksum(self, ip_header:Union[IPv4, IPv6]):
+        """Update the packet checksum to enable integrity check.
+         Each addend is 16 bits."""
+        # TODO: Length does not include data length
+        # self.length = 8 + len(self.data)
+        self.length = 8 + 0
+
+        if isinstance(ip_header, IPv4):
+            source_list = [int(octet) for octet in ip_header.source.split(".")]
+            destination_list = [int(octet) for octet in
+                                ip_header.destination.split(".")]
+            source_upper = (source_list[0] << 8) + source_list[1]
+            source_lower = (source_list[2] << 8) + source_list[3]
+            destination_upper = (destination_list[0] << 8) + destination_list[1]
+            destination_lower = (destination_list[2] << 8) + destination_list[3]
+            ip_value = (source_upper + source_lower + destination_upper +
+                        destination_lower + ip_header.protocol + self.length)
+        else:
+            # TODO: Implement IPv6 header analysis
+            ip_value = 0
+
+        block_sum = ip_value + self.source_p + self.destination_p + self.length + self._value_by_16_bits(self.data)
+
+        while block_sum > 65535:
+            carry = block_sum >> 16
+            block_sum = (block_sum & 65535) + carry
+
+        self.checksum = ~block_sum & 65535
+
+    def pack(self, ip_header:Union[IPv4, IPv6], value=None):
+        """Pack the struct in a binary representation.
+
+        Merge some fields to ensure correct packing.
+
+        Returns:
+            bytes: Binary representation of this instance.
+
+        """
+        self._update_checksum(ip_header)
+        return super().pack(value)
+
+    def unpack(self, buff, offset=0):
+        """Unpack a binary struct into this object's attributes.
+
+        Return the values instead of the lib's basic types.
+
+        Args:
+            buff (bytes): Binary buffer.
+            offset (int): Where to begin unpacking.
+
+        Raises:
+            :exc:`~.exceptions.UnpackException`: If unpack fails.
+
+        """
+        super().unpack(buff, offset)
+        self.source_p = self.source_p.value
+        self.destination_p = self.destination_p.value
+        self.length = self.length.value
+        self.checksum = self.checksum.value
+        self.data = self.data.value

--- a/shared/extd_nw_types.py
+++ b/shared/extd_nw_types.py
@@ -13,12 +13,12 @@ __all__ = ('TCP', 'UDP')
 
 
 class TCP(GenericStruct):
-    """TCP - Being developed """
+    """TCP packet"""
 
-    source_p = UBInt16()
-    destination_p = UBInt16()
-    sequence_n = UBInt32()
-    acknowledgment_n = UBInt32()
+    src_port = UBInt16()
+    dst_port = UBInt16()
+    seq = UBInt32()
+    ack = UBInt32()
     _length_flags = UBInt16()
     window = UBInt16()
     checksum = UBInt16()
@@ -26,18 +26,18 @@ class TCP(GenericStruct):
     options = BinaryData()
     data = BinaryData()
 
-    def __init__(self, source_p:int=0, destination_p:int=0, sequence_n:int=0, acknowledgment_n:int=0, h_length:int=5,
-                 flags:int=2, window:int=0, checksum:int=0, urgent_pointer:int=0, options:bytes=b'', data:bytes=b''):
+    def __init__(self, src_port=0, dst_port=0, seq=0, ack=0, length=5,
+                 flags=2, window=0, checksum=0, urgent_pointer=0, options=b'', data=b''):
         """
         These default values are considering this TCP message is first sent, initiating
          handshake.
 
         Args:
-            source_p(int): Source port. Defaults to 0
-            destination_p(int): Destination port. Defaults to 0
-            sequence_n(int): Sequence number (raw). Random number [0, 4294967296]
-            acknowledgment_n(int): Acknowledgment number (raw). Defaults to 0
-            h_length(int): Header length, data offset. Defaults(minimun) to 5 words
+            src_port(int): Source port. Defaults to 0
+            dst_port(int): Destination port. Defaults to 0
+            seq(int): Sequence number (raw). Random number [0, 4294967296]
+            ack(int): Acknowledgment number (raw). Defaults to 0
+            length(int): Header length, data offset. Defaults(minimun) to 5 words
             flags(bits): Flags. Defaults to 2 or 0000 0000 0010. Divided in:
                 reserved: Reserved, not used yet. Defaults to 000
                 ecn_acc: Accurate ECN. Defaults to 0
@@ -49,27 +49,47 @@ class TCP(GenericStruct):
                 reset: Reset. Defaults to 0
                 syn: Syn. Defaults to 1
                 fin: Fin. Defaults to 0
-            window(int): Window. Defaults to 43690
+            window(int): Window. Defaults to 0
             checksum(int): Checksum. Defaults to 0
             urgent_pointer(int): Urgent pointer. Defaults to 0
             options(bytes): Options. Defaults to empty bytes
             data(bytes): Data. Defaults to empty bytes
+
+        TCP Header Format:
+             0                   1                   2                   3
+             0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 
+            +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+            |          Source Port          |       Destination Port        |
+            +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+            |                        Sequence Number                        |
+            +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+            |                    Acknowledgment Number                      |
+            +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+            |  Data |           |U|A|P|R|S|F|                               |
+            | Offset| Reserved  |R|C|S|S|Y|I|            Window             |
+            |       |           |G|K|H|T|N|N|                               |
+            +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+            |           Checksum            |         Urgent Pointer        |
+            +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+            |                    Options                    |    Padding    |
+            +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+            |                             data                              |
+            +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
         """
         super().__init__()
-        self.source_p = source_p
-        self.destination_p = destination_p
-        self.sequence_n = sequence_n if sequence_n != 0 else randrange(4294967296)
-        self.acknowledgment_n = acknowledgment_n
-        self.h_length = h_length
+        self.src_port = src_port
+        self.dst_port = dst_port
+        self.seq = seq if seq != 0 else randrange(4294967296)
+        self.ack = ack
+        self.length = length
         self.flags = flags
-        # window default value (b'\xaa\xaa') is an arbitrary number until advised otherwise.
         self.window = window
         self.checksum = checksum
         self.urgent_pointer = urgent_pointer
         self.options = options
         self.data = data
 
-    def _value_by_half_word(self, value: bytes) -> int:
+    def _value_by_16_bits(self, value: bytes) -> int:
         """Calculate the integer value of the argument partitioned by 2 bytes."""
         total = 0
         while value:
@@ -77,17 +97,17 @@ class TCP(GenericStruct):
             value = value[:-2]
         return total
 
-    def _update_checksum(self, ip_header: Union[IPv4, IPv6]):
+    def _update_checksum(self, ip_header:Union[IPv4, IPv6]=None):
         """Update the packet checksum to enable integrity check.
          Each addend is 16 bits."""
         # TODO: Overflown data in practice (91 bytes).
         #       Lenght currently is not accurate
-        # self.h_length = 5 + (len(self.options) // 4) + (len(self.data) // 4)
-        self.h_length = 5 + (len(self.options) // 4) + 0
-        self._length_flags = self.h_length << 12 | self.flags
+        # self.length = 5 + (len(self.options) // 4) + (len(self.data) // 4)
+        self.length = 5 + (len(self.options) // 4) + 0
+        self._length_flags = self.length << 12 | self.flags
 
-        sequence_hex = hex(self.sequence_n)[2:]
-        acknowledgment_hex = hex(self.acknowledgment_n)[2:]
+        sequence_hex = hex(self.seq)[2:]
+        acknowledgment_hex = hex(self.ack)[2:]
         sequence_upper = int(sequence_hex[:4] or '0', 16)
         sequence_lower = int(sequence_hex[-4:] or '0', 16)
         acknowledgment_upper = int(acknowledgment_hex[:4] or '0', 16)
@@ -102,16 +122,16 @@ class TCP(GenericStruct):
             destination_upper = (destination_list[0] << 8) + destination_list[1]
             destination_lower = (destination_list[2] << 8) + destination_list[3]
             ip_value = (source_upper + source_lower + destination_upper +
-                        destination_lower + ip_header.protocol + (self.h_length * 4))
+                        destination_lower + ip_header.protocol + (self.length * 4))
         else:
             # TODO: Implement IPv6 header analysis
             ip_value = 0
 
-        block_sum = (self.source_p + self.destination_p + sequence_upper +
+        block_sum = (self.src_port + self.dst_port + sequence_upper +
                          sequence_lower + acknowledgment_upper + acknowledgment_lower +
                          self._length_flags + self.window + 0 + self.urgent_pointer +
-                         self._value_by_half_word(self.options) +
-                         self._value_by_half_word(self.data) + ip_value)
+                         self._value_by_16_bits(self.options) +
+                         self._value_by_16_bits(self.data) + ip_value)
         
         while block_sum > 65535:
             carry = block_sum >> 16
@@ -119,7 +139,7 @@ class TCP(GenericStruct):
 
         self.checksum = ~block_sum & 65535
 
-    def pack(self, ip_header: Union[IPv4, IPv6], value=None):
+    def pack(self, ip_header:Union[IPv4, IPv6]=None, value=None):
         """Pack the struct in a binary representation.
 
         Merge some fields to ensure correct packing.
@@ -145,17 +165,17 @@ class TCP(GenericStruct):
 
         """
         super().unpack(buff, offset)
-        self.source_p = self.source_p.value
-        self.destination_p = self.destination_p.value
-        self.sequence_n = self.sequence_n.value
-        self.acknowledgment_n = self.acknowledgment_n.value
-        self.h_length = self._length_flags.value >> 12
+        self.src_port = self.src_port.value
+        self.dst_port = self.dst_port.value
+        self.seq = self.seq.value
+        self.ack = self.ack.value
+        self.length = self._length_flags.value >> 12
         self.flags = self._length_flags.value & 4095
         self.window = self.window.value
         self.checksum = self.checksum.value
 
-        if self.h_length > 5:
-            option_size = (self.h_length - 5) * 4
+        if self.length > 5:
+            option_size = (self.length - 5) * 4
             self.data = self.options.value[option_size:]
             self.options = self.options.value[:option_size]
         else:
@@ -164,27 +184,40 @@ class TCP(GenericStruct):
 
 
 class UDP(GenericStruct):
-    """ UDP - Being developed """
+    """ UDP packet"""
 
-    source_p = UBInt16()
-    destination_p = UBInt16()
+    src_port = UBInt16()
+    dst_port = UBInt16()
     length = UBInt16()
     checksum = UBInt16()
     data = BinaryData()
     
-    def __init__(self, source_p:int=0, destination_p:int=0, length:int=0, checksum:int=0, data:bytes=b''):
+    def __init__(self, src_port=0, dst_port=0, length=0, checksum=0, data=b''):
         """Create an UDP header with default values.
 
         Args:
-            source_p(int): Source port. Defaults to 0
-            destination_p(int): Destination port. Defaults to 0
+            src_port(int): Source port. Defaults to 0
+            dst_port(int): Destination port. Defaults to 0
             length(int): Length. Defaults to 8 (minimum in bytes)
             checksum(int): Checksum. Defaults to 0
             data(bytes): Data. Defults to empty bytes
 
+        User Datagram Header Format:
+
+             0      7 8     15 16    23 24    31
+            +--------+--------+--------+--------+
+            |     Source      |   Destination   |
+            |      Port       |      Port       |
+            +--------+--------+--------+--------+
+            |                 |                 |
+            |     Length      |    Checksum     |
+            +--------+--------+--------+--------+
+            |
+            |          data octets ...
+            +---------------- ...
         """
-        self.source_p = source_p
-        self.destination_p = destination_p
+        self.src_port = src_port
+        self.dst_port = dst_port
         self.length = length
         self.checksum = checksum
         self.data = data
@@ -197,7 +230,7 @@ class UDP(GenericStruct):
             value = value[:-2]
         return total
 
-    def _update_checksum(self, ip_header:Union[IPv4, IPv6]):
+    def _update_checksum(self, ip_header:Union[IPv4, IPv6]=None):
         """Update the packet checksum to enable integrity check.
          Each addend is 16 bits."""
         # TODO: Length does not include data length
@@ -218,7 +251,7 @@ class UDP(GenericStruct):
             # TODO: Implement IPv6 header analysis
             ip_value = 0
 
-        block_sum = ip_value + self.source_p + self.destination_p + self.length + self._value_by_16_bits(self.data)
+        block_sum = ip_value + self.src_port + self.dst_port + self.length + self._value_by_16_bits(self.data)
 
         while block_sum > 65535:
             carry = block_sum >> 16
@@ -226,7 +259,7 @@ class UDP(GenericStruct):
 
         self.checksum = ~block_sum & 65535
 
-    def pack(self, ip_header:Union[IPv4, IPv6], value=None):
+    def pack(self, ip_header:Union[IPv4, IPv6]=None, value=None):
         """Pack the struct in a binary representation.
 
         Merge some fields to ensure correct packing.
@@ -238,7 +271,7 @@ class UDP(GenericStruct):
         self._update_checksum(ip_header)
         return super().pack(value)
 
-    def unpack(self, buff, offset=0):
+    def unpack(self, buff:bytes, offset=0):
         """Unpack a binary struct into this object's attributes.
 
         Return the values instead of the lib's basic types.
@@ -252,8 +285,8 @@ class UDP(GenericStruct):
 
         """
         super().unpack(buff, offset)
-        self.source_p = self.source_p.value
-        self.destination_p = self.destination_p.value
+        self.src_port = self.src_port.value
+        self.dst_port = self.dst_port.value
         self.length = self.length.value
         self.checksum = self.checksum.value
         self.data = self.data.value

--- a/tests/unit/shared/test_extd_nw_types.py
+++ b/tests/unit/shared/test_extd_nw_types.py
@@ -1,0 +1,123 @@
+"""Testing TCP and UPD struct packets"""
+
+# pylint: disable=protected-access
+from napps.amlight.sdntrace.shared.extd_nw_types import TCP, UDP
+from pyof.foundation.network_types import IPv4
+
+
+class TestTCP:
+    """Test TCP"""
+
+    def test_tcp_pack(self):
+        """Test pack"""
+        ip_pk = IPv4()
+        ip_pk.source = "127.0.0.1"
+        ip_pk.destination = "127.0.0.2"
+        ip_pk.protocol = 6
+        tcp_pk = TCP()
+        tcp_pk.src_port = 1
+        tcp_pk.dst_port = 2
+        tcp_pk.seq = 11111
+        tcp_pk.window = 43690
+        tcp_pk.data = b"mocked"
+        expected_pack = b"\x00\x01\x00\x02\x00\x00+g\x00\x00"
+        expected_pack += b"\x00\x00P\x02\xaa\xaaz$\x00\x00mocked"
+        actual_pack = tcp_pk.pack(ip_pk)
+        assert expected_pack == actual_pack
+
+    def test_tcp_unpack(self):
+        """Test unpack"""
+        ip_pk = IPv4()
+        ip_pk.source = "127.0.0.1"
+        ip_pk.destination = "127.0.0.2"
+        ip_pk.protocol = 6
+        exp_pk = TCP()
+        exp_pk.src_port = 1
+        exp_pk.dst_port = 2
+        exp_pk.seq = 11111
+        exp_pk.window = 43690
+        exp_pk.data = b"mocked"
+        data = b"\x00\x01\x00\x02\x00\x00+g\x00\x00"
+        data += b"\x00\x00P\x02\xaa\xaaz$\x00\x00mocked"
+        actual_pk = TCP()
+        actual_pk.unpack(data)
+        assert actual_pk == exp_pk
+
+    def test_tcp_update_checksum_ipv4(self):
+        """Test _update_checksum with IPv4"""
+        ip_pk = IPv4()
+        ip_pk.source = "127.0.0.1"
+        ip_pk.destination = "127.0.0.2"
+        ip_pk.protocol = 6
+        tcp_pk = TCP()
+        tcp_pk.src_port = 1
+        tcp_pk.dst_port = 2
+        tcp_pk.seq = 11111
+        tcp_pk.window = 43690
+        tcp_pk.pack(ip_pk)
+        assert tcp_pk.checksum == 45155
+
+        # Currently data does not count for length
+        prev_length = tcp_pk.length
+        tcp_pk.data = b"mocked"
+        tcp_pk.pack()
+        assert tcp_pk.length == prev_length
+
+    def test_tcp_value_by_16_bits(self):
+        """Test _value_by_16_bits"""
+        data = b"A word is 4 bytes"
+        tcp_pk = TCP()
+        actual_value = tcp_pk._value_by_16_bits(data)
+        assert actual_value == 163130
+
+
+class TestUDP:
+    """Test UDP"""
+
+    def test_udp_pack(self):
+        """Test pack"""
+        ip_pk = IPv4()
+        ip_pk.source = "127.0.0.1"
+        ip_pk.destination = "127.0.0.2"
+        ip_pk.protocol = 17
+        upd_pk = UDP()
+        upd_pk.src_port = 1
+        upd_pk.dst_port = 2
+        upd_pk.data = b"mocked"
+        expected_pack = b"\x00\x01\x00\x02\x00\x08\xcb\x98mocked"
+        assert upd_pk.pack(ip_pk) == expected_pack
+
+    def test_udp_unpack(self):
+        """Test unpack"""
+        ip_pk = IPv4()
+        ip_pk.source = "127.0.0.1"
+        ip_pk.destination = "127.0.0.2"
+        ip_pk.protocol = 17
+        exp_pk = UDP()
+        exp_pk.src_port = 1
+        exp_pk.dst_port = 2
+        exp_pk.data = b"mocked"
+        data = b"\x00\x01\x00\x02\x00\x08\xcb\x98mocked"
+        actual_pk = UDP()
+        actual_pk.unpack(data)
+        assert actual_pk == exp_pk
+
+    def test_udp_update_checksum_ipv4(self):
+        """Test _update_checksum"""
+        ip_pk = IPv4()
+        ip_pk.source = "127.0.0.1"
+        ip_pk.destination = "127.0.0.2"
+        ip_pk.protocol = 17
+        udp_pk = UDP()
+        udp_pk.src_port = 1
+        udp_pk.dst_port = 2
+        udp_pk.data = b"mocked"
+        udp_pk.pack(ip_pk)
+        assert udp_pk.checksum == 52120
+
+    def test_udp_value_by_16_bits(self):
+        """Test _value_by_16_bits"""
+        data = b"A word is 4 bytes"
+        udp_pk = UDP()
+        actual_value = udp_pk._value_by_16_bits(data)
+        assert actual_value == 163130

--- a/tests/unit/tracing/test_trace_entries.py
+++ b/tests/unit/tracing/test_trace_entries.py
@@ -521,3 +521,12 @@ class TestLoadEntries:
         assert self.trace_entries.dl_vlan == eth["dl_vlan"]
         assert self.trace_entries.dpid == dpid["dpid"]
         assert self.trace_entries.in_port == dpid["in_port"]
+
+    def test_proto_missing_tp(self):
+        """Test missing tp when nw_proto is present"""
+        dpid = {"dpid": "a", "in_port": 1}
+        ip = {"nw_proto": 6}
+        switch = {"switch": dpid, "ip": ip}
+        entries = {"trace": switch}
+        with pytest.raises(ValueError):
+            self.trace_entries.load_entries(entries)

--- a/tracing/trace_entries.py
+++ b/tracing/trace_entries.py
@@ -352,6 +352,11 @@ class TraceEntries(object):
             if 'nw_tos' in ip_:
                 self.nw_tos = ip_['nw_tos']
 
+            if 'nw_proto' in ip_:
+                self.nw_proto = ip_['nw_proto']
+                if 'tp' not in trace:
+                    raise ValueError("Error: tp not provided")
+
         # Basic entries['trace']['ip']
         if 'tp' in trace:
             tp_ = trace['tp']

--- a/tracing/trace_pkt.py
+++ b/tracing/trace_pkt.py
@@ -85,9 +85,9 @@ def prepare_next_packet(trace_entries, result, event):
         in_port = event.message.in_port
         trace_entries.in_port = in_port
 
-    trace_entries.dl_vlan = _get_vlan_from_pkt(
-        event.content['message'].data.value)
-
+    vlan = _get_vlan_from_pkt(event.content['message'].data.value)
+    if vlan:
+        trace_entries.dl_vlan = vlan
     return trace_entries, color, switch
 
 
@@ -173,8 +173,8 @@ def _create_tcp_packet(trace_entries) -> TCP:
         tcp packet
     """
     tcp_pkt = TCP()
-    tcp_pkt.source_p = trace_entries.tp_src
-    tcp_pkt.destination_p = trace_entries.tp_dst
+    tcp_pkt.src_port = trace_entries.tp_src
+    tcp_pkt.dst_port = trace_entries.tp_dst
     return tcp_pkt
 
 
@@ -187,8 +187,8 @@ def _create_udp_packet(trace_entries) -> UDP:
         tcp message
     """
     udp_pkt = UDP()
-    udp_pkt.source_p = trace_entries.tp_src
-    udp_pkt.destination_p = trace_entries.tp_dst
+    udp_pkt.src_port = trace_entries.tp_src
+    udp_pkt.dst_port = trace_entries.tp_dst
     return udp_pkt
 
 
@@ -217,5 +217,7 @@ def _get_vlan_from_pkt(data):
     """
     ethernet = Ethernet()
     ethernet.unpack(data)
-    vlan = ethernet.vlans[0]
-    return vlan.vid
+    vlans = ethernet.vlans
+    if vlans:
+        return vlans[0].vid
+    return None

--- a/tracing/trace_pkt.py
+++ b/tracing/trace_pkt.py
@@ -8,7 +8,7 @@ import dill
 from pyof.foundation.network_types import Ethernet, IPv4, VLAN
 from napps.amlight.sdntrace import constants
 from napps.amlight.sdntrace.tracing.trace_msg import TraceMsg
-# from napps.amlight.sdntrace.shared.extd_nw_types import TCP, UDP
+from napps.amlight.sdntrace.shared.extd_nw_types import TCP, UDP
 from napps.amlight.sdntrace.shared.switches import Switches
 from napps.amlight.sdntrace.shared.colors import Colors
 
@@ -41,17 +41,13 @@ def generate_trace_pkt(trace_entries, color, r_id):
     if ethernet.ether_type == constants.IPV4:
         ip_pkt = _create_ip_packet(trace_entries)
         if ip_pkt.protocol == constants.TCP:
-            # No dissector for TCP yet
-            ip_pkt.data = dill.dumps(msg)
-
-            # tp_pkt = _create_tcp_packet(trace_entries)
-            # ip_pkt.data = tp_pkt.pack()
+            tp_pkt = _create_tcp_packet(trace_entries)
+            tp_pkt.data = dill.dumps(msg)
+            ip_pkt.data = tp_pkt.pack(ip_pkt)
         elif ip_pkt.protocol == constants.UDP:
-            # No dissector for UDP yet
-            ip_pkt.data = dill.dumps(msg)
-
-            # tp_pkt = _create_udp_packet(trace_entries)
-            # ip_pkt.data = tp_pkt.pack()
+            udp_pkt = _create_udp_packet(trace_entries)
+            udp_pkt.data = dill.dumps(msg)
+            ip_pkt.data = udp_pkt.pack(ip_pkt)
         else:
             ip_pkt.data = dill.dumps(msg)
 
@@ -117,19 +113,14 @@ def process_packet(ethernet):
         trace_msg = ip_pkt.data
 
         if ip_pkt.protocol == constants.TCP:
-            # TCP and UDP are not yet supported
-            # transport = TCP()
-            # transport.parse(ethernet.data.value, offset)
-            # offset += transport.length
-            # trace_msg = transport.data
-            trace_msg = ip_pkt.data
+            transport = TCP()
+            transport.unpack(ip_pkt.data)
+            trace_msg = transport.data
 
-        if ip_pkt.protocol == constants.UDP:
-            # transport = UDP()
-            # transport.parse(ethernet.data.value, offset)
-            # offset += transport.length
-            # trace_msg = transport.data
-            trace_msg = ip_pkt.data
+        elif ip_pkt.protocol == constants.UDP:
+            transport = UDP()
+            transport.unpack(ip_pkt.data)
+            trace_msg = transport.data
 
     return trace_msg
 
@@ -157,7 +148,7 @@ def _create_ethernet_frame(trace_entries, color):
     return ethernet
 
 
-def _create_ip_packet(trace_entries):
+def _create_ip_packet(trace_entries) -> IPv4:
     """ Create an IP packet using TraceEntries
 
     Args:
@@ -173,7 +164,7 @@ def _create_ip_packet(trace_entries):
     return ip_pkt
 
 
-def _create_tcp_packet(trace_entries):
+def _create_tcp_packet(trace_entries) -> TCP:
     """ Create a TCP packet using TraceEntries (FUTURE)
 
     Args:
@@ -181,10 +172,13 @@ def _create_tcp_packet(trace_entries):
     Returns:
         tcp packet
     """
-    return trace_entries
+    tcp_pkt = TCP()
+    tcp_pkt.source_p = trace_entries.tp_src
+    tcp_pkt.destination_p = trace_entries.tp_dst
+    return tcp_pkt
 
 
-def _create_udp_packet(trace_entries):
+def _create_udp_packet(trace_entries) -> UDP:
     """ Create an UDP datagram using TraceEntries (FUTURE)
 
     Args:
@@ -192,7 +186,10 @@ def _create_udp_packet(trace_entries):
     Returns:
         tcp message
     """
-    return trace_entries
+    udp_pkt = UDP()
+    udp_pkt.source_p = trace_entries.tp_src
+    udp_pkt.destination_p = trace_entries.tp_dst
+    return udp_pkt
 
 
 def _get_node_color_from_dpid(dpid):


### PR DESCRIPTION
Closes #70

### Summary

Added TCP and UDP support over a IPv4 header

### Local Tests
Performed some traces.
Additionally set up only TCP/UDP matching flow in a topology.

### End-to-End Tests
From [PR](https://github.com/kytos-ng/kytos-end-to-end-tests/pull/313)
```
+ python3 -m pytest tests/test_e2e_40_sdntrace.py --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.1.1, pluggy-1.5.0
rootdir: /tests
plugins: rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
collected 16 items

tests/test_e2e_40_sdntrace.py ................                           [100%]
```
