### PR TITLE
Narrowed `tp` requirements

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -67,7 +67,7 @@ paths:
             application/json:
               schema:
                 oneOf:
-                  - $ref: '#/components/schemas/TransactionProgram'
+                  - $ref: '#/components/schemas/TransportProtocol'
                   - type: object
                     properties:
                       msg:  # This property will show only error messages
@@ -169,7 +169,7 @@ components:
             ip:
               $ref: '#/components/schemas/InternetProtocol'
             tp:
-              $ref: '#/components/schemas/TransactionProgram'
+              $ref: '#/components/schemas/TransportProtocol'
     Switch: # Can be referenced via '#/components/schemas/Switch'
       type: object
       required:
@@ -215,7 +215,7 @@ components:
         nw_proto:
           type: integer
           format: int32
-    TransactionProgram: # Can be referenced via '#/components/schemas/TransactionProgram'
+    TransportProtocol: # Can be referenced via '#/components/schemas/TransportProtocol'
       type: object
       properties:
         tp_src:

--- a/tests/unit/tracing/test_trace_entries.py
+++ b/tests/unit/tracing/test_trace_entries.py
@@ -530,3 +530,12 @@ class TestLoadEntries:
         entries = {"trace": switch}
         with pytest.raises(ValueError):
             self.trace_entries.load_entries(entries)
+
+    def test_proto_without_tp(self):
+        """Test define proto without needing tp"""
+        dpid = {"dpid": "a", "in_port": 1}
+        ip = {"nw_proto": 1}
+        switch = {"switch": dpid, "ip": ip}
+        entries = {"trace": switch}
+        self.trace_entries.load_entries(entries)
+        assert self.trace_entries.nw_proto == ip["nw_proto"]

--- a/tracing/trace_entries.py
+++ b/tracing/trace_entries.py
@@ -2,7 +2,7 @@
     Class Entries. Used to evaluate entries provided.
 """
 import re
-
+from napps.amlight.sdntrace import constants
 
 DPID_ADDR = re.compile('([0-9A-Fa-f]{2}[-:]){7}[0-9A-Fa-f]{2}$')
 MAC_ADDR = re.compile('([0-9A-Fa-f]{2}[-:]){5}[0-9A-Fa-f]{2}$')
@@ -354,7 +354,8 @@ class TraceEntries(object):
 
             if 'nw_proto' in ip_:
                 self.nw_proto = ip_['nw_proto']
-                if ((ip_['nw_proto'] == 17 or ip_['nw_proto'] == 6) and 'tp' not in trace):
+                if ((ip_['nw_proto'] == constants.UDP or ip_['nw_proto'] == constants.TCP)
+                     and 'tp' not in trace):
                     raise ValueError("Error: tp not provided")
 
         # Basic entries['trace']['ip']

--- a/tracing/trace_entries.py
+++ b/tracing/trace_entries.py
@@ -354,7 +354,7 @@ class TraceEntries(object):
 
             if 'nw_proto' in ip_:
                 self.nw_proto = ip_['nw_proto']
-                if 'tp' not in trace:
+                if ((ip_['nw_proto'] == 17 or ip_['nw_proto'] == 6) and 'tp' not in trace):
                     raise ValueError("Error: tp not provided")
 
         # Basic entries['trace']['ip']


### PR DESCRIPTION
Closes #83
Closes #82 

### Summary

Reduce required `tp` only when TCP and UDP headers are created
Changed schema from `TransactionProgram` to `TransportProtocol`

### Local Tests

Tried to create traces with ICMP, TCP and UDP

### End-to-End Tests
N/A
