### PR TITLE
release: bumped 2024.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,10 +6,12 @@ All notable changes to the sdntrace NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2024.1.0] - 2024-07-23
+***********************
+
 Changed
 =======
 - Updated python environment installation from 3.9 to 3.11
-- Updated test dependencies
 - Added versioning to API requests
 - Upgraded UI framework to Vue3 
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "amlight",
   "name": "sdntrace",
   "description": "An OpenFlow Data Path Tracing",
-  "version": "2023.1.0",
+  "version": "2024.1.0",
   "napp_dependencies": ["amlight/coloring", "kytos/of_core"],
   "license": "GPL3.0",
   "tags": ["experimental", "coloring"],


### PR DESCRIPTION
### Summary

release: bumped 2024.1.0

### Local Tests

N/A

### End-to-End Tests

e2e nightly tests are passing. N/A for this PR.
