### PR TITLE
Fixed error when fetching an in progress trace

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to the sdntrace NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2024.1.1] - 2024-09-12
+***********************
+
+Fixed
+=====
+- Fixed bug when fetching an in progress trace
+
 [2024.1.0] - 2024-07-23
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "amlight",
   "name": "sdntrace",
   "description": "An OpenFlow Data Path Tracing",
-  "version": "2024.1.0",
+  "version": "2024.1.1",
   "napp_dependencies": ["amlight/coloring", "kytos/of_core"],
   "license": "GPL3.0",
   "tags": ["experimental", "coloring"],

--- a/ui/k-info-panel/show_trace_results.kytos
+++ b/ui/k-info-panel/show_trace_results.kytos
@@ -77,11 +77,19 @@ module.exports = {
             async: true,
             dataType: "json",
             type: "GET", 
-            url: `${this.$kytos_server_api}amlight/sdntrace/v1/trace/${this.traceId}`,
+            url: `${self.$kytos_server_api}amlight/sdntrace/v1/trace/${self.traceId}`,
             success: function(response) {
-            self.trace_results = response.result; 
-            self.updateId = response.request_id;
-            self.is_empty = !self.trace_results.length; 
+              if (response?.msg) {
+                let notification = {
+                icon: 'gear',
+                title: 'Trace in progress...'
+                };
+                self.$kytos.eventBus.$emit("setNotification", notification);
+              } else {
+                self.trace_results = response.result; 
+                self.updateId = response.request_id;
+                self.is_empty = !self.trace_results.length; 
+              }
             },
             error: function() { 
               self.is_empty = true;


### PR DESCRIPTION
Closes #93 

### Summary

Issue #93 was caused by trying to fetch data from a trace that was still "in progress" and thus had no data. This pull request resolves that issue by checking if the trace is still "in progress,"  and if so, it sends a notification.

### Local Tests

Fetched an "in progress" trace, and a notification was returned instead of an error.

### Images

![image](https://github.com/user-attachments/assets/4587636f-44b8-46bc-94e2-10c927f5f8cb)
