### PR TITLE
Added customClass to k-inputs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,15 +8,12 @@ All notable changes to the sdntrace NApp will be documented in this file.
 
 Changed
 =======
-<<<<<<< HEAD
 - Updated watchers
 
 Added
 =====
 - Inputs used for display only were disabled
-=======
 - k-inputs now use customClass prop to add CSS classes
->>>>>>> 762a95a (Updated CHANGELOG.rst)
 
 [2024.1.1] - 2024-09-12
 ***********************

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,11 +8,15 @@ All notable changes to the sdntrace NApp will be documented in this file.
 
 Changed
 =======
+<<<<<<< HEAD
 - Updated watchers
 
 Added
 =====
 - Inputs used for display only were disabled
+=======
+- k-inputs now use customClass prop to add CSS classes
+>>>>>>> 762a95a (Updated CHANGELOG.rst)
 
 [2024.1.1] - 2024-09-12
 ***********************

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -13,8 +13,7 @@
                           @blur="onblur_dpids"
                           >{{ dpid }}
             </k-input-auto>
-            
-            <k-input class="k-input interface-label" v-model:value="dpid_display" icon="none" :isDisabled="true"
+            <k-input customClass="k-input interface-label" v-model:value="dpid_display" icon="none" :isDisabled="true"
                       >{{ dpid_display }}</k-input>
             
             <k-input-auto id="in_port" v-model:value="in_port"
@@ -25,8 +24,7 @@
                           @blur="onblur_ports"
                       >{{ in_port }}
             </k-input-auto>
-            
-            <k-input class="k-input interface-label" v-model:value="port_name" icon="none" :isDisabled="true"
+            <k-input customClass="k-input interface-label" v-model:value="port_name" icon="none" :isDisabled="true"
                       >{{ port_name }}</k-input>
           </k-accordion-item>
 


### PR DESCRIPTION
Closes #100 

### Summary

K-inputs now use the new customClass prop to add their CSS classes instead of just using class, so that they are compatible with the vue3-sfc-loader.
For these changes to work, you need the latest custom class additions from the main UI repo:
https://github.com/kytos-ng/ui/pull/118#issue-2727981658

### Local Tests

I ran it on my local environment and no errors were produced.
