### PR TITLE
Removed customClass

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ All notable changes to the sdntrace NApp will be documented in this file.
 Changed
 =======
 - Updated watchers
+- Removed customClass
 
 Added
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,12 +9,10 @@ All notable changes to the sdntrace NApp will be documented in this file.
 Changed
 =======
 - Updated watchers
-- Removed customClass
 
 Added
 =====
 - Inputs used for display only were disabled
-- k-inputs now use customClass prop to add CSS classes
 
 [2024.1.1] - 2024-09-12
 ***********************

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -13,7 +13,7 @@
                           @blur="onblur_dpids"
                           >{{ dpid }}
             </k-input-auto>
-            <k-input customClass="k-input interface-label" v-model:value="dpid_display" icon="none" :isDisabled="true"
+            <k-input class="k-input interface-label" v-model:value="dpid_display" icon="none" :isDisabled="true"
                       >{{ dpid_display }}</k-input>
             
             <k-input-auto id="in_port" v-model:value="in_port"
@@ -24,7 +24,7 @@
                           @blur="onblur_ports"
                       >{{ in_port }}
             </k-input-auto>
-            <k-input customClass="k-input interface-label" v-model:value="port_name" icon="none" :isDisabled="true"
+            <k-input class="k-input interface-label" v-model:value="port_name" icon="none" :isDisabled="true"
                       >{{ port_name }}</k-input>
           </k-accordion-item>
 


### PR DESCRIPTION
Closes #102 

### Summary

The customClass was removed since the issue with CSS was fixed.

### Local Tests

The CSS functioned as should.

### End-to-End Tests