### PR TITLE
Fixed the CSS for the k-input-autocomplete list

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Added
 =====
 - Inputs used for display only were disabled
 
+Fixed
+=====
+- Fixed the CSS for the ``k-input-auto``
+
 [2024.1.1] - 2024-09-12
 ***********************
 

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -3,7 +3,7 @@
     <div class="scroll">
       <k-accordion>
         <k-accordion-item title="Trace">
-          <k-accordion-item title="Required Switch Parameters">
+          <k-accordion-item class="visible" title="Required Switch Parameters">
           
             <k-input-auto id="dpid" v-model:value="dpid"
                           title="DPID:"
@@ -28,14 +28,14 @@
                       >{{ port_name }}</k-input>
           </k-accordion-item>
 
-          <k-accordion-item title="Eth Parameters">
+          <k-accordion-item class="visible" title="Eth Parameters">
             <k-input icon="arrow-right" title="dl_vlan:" placeholder="dl_vlan" v-model:value="eth.dl_vlan">{{ eth.dl_vlan }}</k-input>
             <k-input icon="arrow-right" title="dl_type:" placeholder="dl_type" v-model:value="eth.dl_type">{{ eth.dl_type }}</k-input>
             <k-input icon="arrow-right" title="dl_src:" placeholder="dl_src" v-model:value="eth.dl_src">{{ eth.dl_src }}</k-input>
             <k-input icon="arrow-right" title="dl_dst:" placeholder="dl_dst" v-model:value="eth.dl_dst" >{{ eth.dl_dst }}</k-input>
           </k-accordion-item>
           
-          <k-accordion-item title="IP Parameters">
+          <k-accordion-item  title="IP Parameters">
             <k-accordion-item title="IPV4">
               <k-input icon="arrow-right" title="nw_src:" placeholder="nw_src" v-model:value="ip.nw_src">{{ ip.nw_src }}</k-input>
               <k-input icon="arrow-right" title="nw_dst:" placeholder="nw_dst" v-model:value="ip.nw_dst">{{ ip.nw_dst }}</k-input>
@@ -339,5 +339,8 @@ module.exports = {
     outline: 50;
     border: 1px #515151 solid;
     border-radius: 3px;
+  }
+  .visible .tab-content, .visible {
+    overflow: visible !important;
   }
 </style>

--- a/ui/k-toolbar/main.kytos
+++ b/ui/k-toolbar/main.kytos
@@ -35,7 +35,7 @@
             <k-input icon="arrow-right" title="dl_dst:" placeholder="dl_dst" v-model:value="eth.dl_dst" >{{ eth.dl_dst }}</k-input>
           </k-accordion-item>
           
-          <k-accordion-item  title="IP Parameters">
+          <k-accordion-item title="IP Parameters">
             <k-accordion-item title="IPV4">
               <k-input icon="arrow-right" title="nw_src:" placeholder="nw_src" v-model:value="ip.nw_src">{{ ip.nw_src }}</k-input>
               <k-input icon="arrow-right" title="nw_dst:" placeholder="nw_dst" v-model:value="ip.nw_dst">{{ ip.nw_dst }}</k-input>


### PR DESCRIPTION
Closes #104 

### Summary

The Kytos accordion that the k-input auto-complete resided in had its overflow disabled, meaning that the k-input-auto's list could not extend further than the accordion's area.

### Local Tests

The k-input-auto's list now displays properly.

![image](https://github.com/user-attachments/assets/4fe36906-0793-4a38-82d2-16c4552b1713)


### End-to-End Tests
