### PR TITLE
release: bumped 2025.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@ All notable changes to the sdntrace NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2025.2.0] - 2026-02-02
+***********************
+
 Fixed
 =====
 - Catching pickle error to avoid crashing for invalid packets.

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "amlight",
   "name": "sdntrace",
   "description": "An OpenFlow Data Path Tracing",
-  "version": "2025.1.0",
+  "version": "2025.2.0",
   "napp_dependencies": ["amlight/coloring", "kytos/of_core"],
   "license": "GPL3.0",
   "tags": ["experimental", "coloring"],


### PR DESCRIPTION
Related to https://github.com/kytos-ng/kytos/issues/603

### Summary

See updated changelog file 

### Local Tests

N/A

### End-to-End Tests

N/A (nightly tests passing)
