### PR TITLE
allow configuring the trace timeout via settings.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,10 @@ All notable changes to the sdntrace NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Changed
+=======
+- Added the trace timeout config into ``settings.py`` (which can still be overwritten from Trace request payload)
+
 [2025.2.0] - 2026-02-02
 ***********************
 

--- a/settings.py
+++ b/settings.py
@@ -15,3 +15,6 @@ PARALLEL_TRACES = 10
 
 # URL for coloring app
 COLORS_URL = "http://localhost:8181/api/amlight/coloring/colors"
+
+# Timeout to wait for packet-in
+TIMEOUT = 3.0

--- a/settings.py
+++ b/settings.py
@@ -17,4 +17,4 @@ PARALLEL_TRACES = 10
 COLORS_URL = "http://localhost:8181/api/amlight/coloring/colors"
 
 # Timeout to wait for packet-in
-TIMEOUT = 3.0
+TIMEOUT = 0.5

--- a/tests/unit/tracing/test_tracer.py
+++ b/tests/unit/tracing/test_tracer.py
@@ -634,7 +634,7 @@ class TestTracePath:
     def test_send_trace_probe_pre_ended(self, mock_get_switch):
         """Test send_trace_probe when trace ended prematurely."""
         mock_get_switch.return_value = True
-        initial_entries = MagicMock(dpid="00:01")
+        initial_entries = MagicMock(dpid="00:01", step_timeout=0.5)
         tracer = TracePath(self.trace_manager, 3001, initial_entries)
 
         tracer.trace_ended = True

--- a/tracing/trace_entries.py
+++ b/tracing/trace_entries.py
@@ -28,7 +28,7 @@ class TraceEntries(object):
         self._nw_proto = 0
         self._tp_src = 0
         self._tp_dst = 0
-        self.timeout = settings.TIMEOUT
+        self.timeout = max(float(settings.TIMEOUT), 0)
         self.step_timeout = 0.5
         self.init_entries = dict()  # User request
 

--- a/tracing/trace_entries.py
+++ b/tracing/trace_entries.py
@@ -3,6 +3,7 @@
 """
 import re
 from napps.amlight.sdntrace import constants
+from napps.amlight.sdntrace import settings
 
 DPID_ADDR = re.compile('([0-9A-Fa-f]{2}[-:]){7}[0-9A-Fa-f]{2}$')
 MAC_ADDR = re.compile('([0-9A-Fa-f]{2}[-:]){5}[0-9A-Fa-f]{2}$')
@@ -27,7 +28,8 @@ class TraceEntries(object):
         self._nw_proto = 0
         self._tp_src = 0
         self._tp_dst = 0
-        self.timeout = 0.5
+        self.timeout = settings.TIMEOUT
+        self.step_timeout = 0.5
         self.init_entries = dict()  # User request
 
     @property

--- a/tracing/trace_manager.py
+++ b/tracing/trace_manager.py
@@ -151,7 +151,7 @@ class TraceManager(object):
         try:
             trace_entries = TraceEntries()
             trace_entries.load_entries(entries)
-        except ValueError as msg:
+        except (ValueError, TypeError) as msg:
             return str(msg)
 
         init_switch = Switches().get_switch(trace_entries.dpid)

--- a/tracing/tracer.py
+++ b/tracing/tracer.py
@@ -138,6 +138,9 @@ class TracePath(object):
             Timeout
             {switch & port}
         """
+        step_timeout = self.init_entries.step_timeout
+        if step_timeout <= 0:
+            step_timeout = 0.5
         timeout_control = 0  # Controls the timeout of 1 second and two tries
         while not self.trace_ended:
             log.info(f'Trace {self.id}: Sending POut to switch:'
@@ -146,12 +149,14 @@ class TracePath(object):
             send_packet_out(self.trace_mgr.controller,
                             switch, in_port, probe_pkt)
 
-            step_tout = 0
+            remaining_time = self.init_entries.timeout
             pkt_in_msg = None
-            while step_tout < self.init_entries.timeout and pkt_in_msg is None:
-                time.sleep(self.init_entries.step_timeout)
-                step_tout += self.init_entries.step_timeout
+            while True:
+                time.sleep(step_timeout)
+                remaining_time -= step_timeout
                 pkt_in_msg = self.get_packet_in()
+                if remaining_time <= 0 or pkt_in_msg is not None:
+                    break
 
             if pkt_in_msg:
                 result = {"dpid": pkt_in_msg["dpid"],

--- a/tracing/tracer.py
+++ b/tracing/tracer.py
@@ -146,8 +146,12 @@ class TracePath(object):
             send_packet_out(self.trace_mgr.controller,
                             switch, in_port, probe_pkt)
 
-            time.sleep(self.init_entries.timeout)
-            pkt_in_msg = self.get_packet_in()
+            step_tout = 0
+            pkt_in_msg = None
+            while step_tout < self.init_entries.timeout and pkt_in_msg is None:
+                time.sleep(self.init_entries.step_timeout)
+                step_tout += self.init_entries.step_timeout
+                pkt_in_msg = self.get_packet_in()
 
             if pkt_in_msg:
                 result = {"dpid": pkt_in_msg["dpid"],


### PR DESCRIPTION
Closes #119

### Summary

See updated changelog file and/or add any other summarized helpful information for reviewers

### Local Tests

### End-to-End Tests

Similar to what we had on PR https://github.com/kytos-ng/kytos/pull/621:

 Running the end-to-end tests with P4OfSwitch and this branch:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: rerunfailures-13.0, asyncio-1.1.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 302 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py s..s.                                      [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py .                                      [100%]

=============================== warnings summary ===============================
../usr/local/lib/python3.11/dist-packages/requests/__init__.py:109
  /usr/local/lib/python3.11/dist-packages/requests/__init__.py:109: RequestsDependencyWarning: urllib3 (1.26.18) or chardet (7.4.3)/charset_normalizer (3.3.2) doesn't match a supported version!
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
= 278 passed, 10 skipped, 7 xfailed, 7 xpassed, 1 warning in 21930.66s (6:05:30) =
```

Here, the outputs for running the branch with OVS and the end-to-end tests [with modifications](https://github.com/kytos-ng/kytos-end-to-end-tests/pull/426):

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /kytos-end-to-end-tests
configfile: pytest.ini
plugins: rerunfailures-13.0, asyncio-1.1.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 302 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py .....                                      [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 25%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 27%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 46%]
tests/test_e2e_17_mef_eline.py .....                                     [ 48%]
tests/test_e2e_18_mef_eline.py .....                                     [ 49%]
tests/test_e2e_20_flow_manager.py ............................           [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 64%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 81%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py s                                      [100%]

=============================== warnings summary ===============================
../usr/local/lib/python3.11/dist-packages/requests/__init__.py:109
  /usr/local/lib/python3.11/dist-packages/requests/__init__.py:109: RequestsDependencyWarning: urllib3 (1.26.18) or chardet (7.4.3)/charset_normalizer (3.3.2) doesn't match a supported version!
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
------------------------------- start/stop times -------------------------------
= 279 passed, 9 skipped, 7 xfailed, 7 xpassed, 1 warning in 14072.84s (3:54:32) =
```