### PR TITLE
fix: introduced `settings.RESULTS_QUEUE_MAX_SIZE=1000` to avoid unbounded trace results growth (mem leak related)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ All notable changes to the sdntrace NApp will be documented in this file.
 Changed
 =======
 - Added the trace timeout config into ``settings.py`` (which can still be overwritten from Trace request payload)
+Introduced ``settings.RESULTS_QUEUE_MAX_SIZE=1000`` to avoid unbounded trace results growth
 
 [2025.2.0] - 2026-02-02
 ***********************

--- a/settings.py
+++ b/settings.py
@@ -18,3 +18,6 @@ COLORS_URL = "http://localhost:8181/api/amlight/coloring/colors"
 
 # Timeout to wait for packet-in
 TIMEOUT = 0.5
+
+# Maximum number of finished trace results kept in memory
+RESULTS_QUEUE_MAX_SIZE = 1000

--- a/tests/unit/tracing/test_trace_manager.py
+++ b/tests/unit/tracing/test_trace_manager.py
@@ -164,6 +164,16 @@ class TestTraceManager:
         trace_id = self.trace_manager.get_id()
         assert trace_id == 30003
 
+    def test_add_result_evicts_oldest_when_over_max(self):
+        """add_result keeps _results_queue bounded via FIFO eviction."""
+        self.trace_manager._results_queue.clear()
+        with patch.object(settings, "RESULTS_QUEUE_MAX_SIZE", 3):
+            for trace_id in range(5):
+                self.trace_manager.add_result(trace_id, {"result": trace_id})
+        # Only the newest 3 results are kept, oldest (0, 1) evicted in order.
+        assert len(self.trace_manager._results_queue) == 3
+        assert list(self.trace_manager._results_queue.keys()) == [2, 3, 4]
+
     @patch("napps.amlight.sdntrace.shared.colors.Colors.aget_switch_color")
     @patch("napps.amlight.sdntrace.tracing.tracer.TracePath.send_trace_probe")
     async def test_trace_pending(self, mock_send_probe, mock_acolors):
@@ -365,6 +375,7 @@ class TestTraceManagerTheadTest:
 
     def setup_method(self):
         """Set up before each test method"""
+        TestTraceManager.create_basic_switches(get_controller_mock())
         TraceManager.run_traces = MagicMock()
         self.trace_manager = TraceManager(controller=get_controller_mock())
         self.trace_manager.stop_traces()
@@ -399,9 +410,9 @@ class TestTraceManagerTheadTest:
         dpid = {"dpid": "00:00:00:00:00:00:00:01", "in_port": 1}
         switch = {"switch": dpid, "eth": eth}
         entries = {"trace": switch}
-        TraceEntries().load_entries(entries)
-
-        trace_entries = self.trace_manager._request_queue = Queue()
+        trace_entries = TraceEntries()
+        trace_entries.load_entries(entries)
+        self.trace_manager._request_queue = Queue()
         _ = await self.trace_manager.new_trace(trace_entries)
 
         trace_thread = threading.Thread(target=self.trace_manager._run_traces)

--- a/tests/unit/tracing/test_trace_manager.py
+++ b/tests/unit/tracing/test_trace_manager.py
@@ -167,10 +167,9 @@ class TestTraceManager:
     def test_add_result_evicts_oldest_when_over_max(self):
         """add_result keeps _results_queue bounded via FIFO eviction."""
         self.trace_manager._results_queue.clear()
-        with patch.object(settings, "RESULTS_QUEUE_MAX_SIZE", 3):
-            for trace_id in range(5):
-                self.trace_manager.add_result(trace_id, {"result": trace_id})
-        # Only the newest 3 results are kept, oldest (0, 1) evicted in order.
+        self.trace_manager._results_queue_max_size = 3
+        for trace_id in range(5):
+            self.trace_manager.add_result(trace_id, {"result": trace_id})
         assert len(self.trace_manager._results_queue) == 3
         assert list(self.trace_manager._results_queue.keys()) == [2, 3, 4]
 

--- a/tracing/trace_manager.py
+++ b/tracing/trace_manager.py
@@ -42,6 +42,7 @@ class TraceManager(object):
         self._request_queue = None
         self._results_queue = OrderedDict()
         self._running_traces:dict[int, TraceEntries] = dict()
+        self._results_queue_max_size = max(int(settings.RESULTS_QUEUE_MAX_SIZE), 1)
 
         # Counters
         self._total_traces_requested = 0
@@ -54,7 +55,7 @@ class TraceManager(object):
         self._async_loop = None
         # To start traces
         self.run_traces()
-
+    
     def stop_traces(self):
         if self._is_tracing_running:
             self._is_tracing_running = False
@@ -120,7 +121,10 @@ class TraceManager(object):
             result: trace result generated using tracer
         """
         self._results_queue[trace_id] = result
-        while len(self._results_queue) > settings.RESULTS_QUEUE_MAX_SIZE:
+        while (
+            self._results_queue
+            and len(self._results_queue) > self._results_queue_max_size
+        ):
             self._results_queue.popitem(last=False)
         self._running_traces.pop(trace_id, None)
 

--- a/tracing/trace_manager.py
+++ b/tracing/trace_manager.py
@@ -55,7 +55,7 @@ class TraceManager(object):
         self._async_loop = None
         # To start traces
         self.run_traces()
-    
+
     def stop_traces(self):
         if self._is_tracing_running:
             self._is_tracing_running = False

--- a/tracing/trace_manager.py
+++ b/tracing/trace_manager.py
@@ -7,7 +7,7 @@ import dill
 import time
 from janus import Queue
 from _thread import start_new_thread as new_thread
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from typing import Optional
 
 from kytos.core import log
@@ -40,7 +40,7 @@ class TraceManager(object):
         # Trace queues
         self._request_dict = dict()
         self._request_queue = None
-        self._results_queue = dict()
+        self._results_queue = OrderedDict()
         self._running_traces:dict[int, TraceEntries] = dict()
 
         # Counters
@@ -120,6 +120,8 @@ class TraceManager(object):
             result: trace result generated using tracer
         """
         self._results_queue[trace_id] = result
+        while len(self._results_queue) > settings.RESULTS_QUEUE_MAX_SIZE:
+            self._results_queue.popitem(last=False)
         self._running_traces.pop(trace_id, None)
 
     def avoid_duplicated_request(self, entries):


### PR DESCRIPTION
Closes #121 

### Summary

See updated changelog file 

### Local Tests

Ran traces

### End-to-End Tests

With this branch:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.2, pluggy-1.6.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
configfile: pytest.ini
plugins: asyncio-1.1.0, rerunfailures-13.0, timeout-2.2.0, anyio-4.3.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 309 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  6%]
tests/test_e2e_06_topology.py .....                                      [  8%]
tests/test_e2e_08_topology.py .                                          [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x....................... [ 22%]
.                                                                        [ 22%]
tests/test_e2e_11_mef_eline.py ........                                  [ 24%]
tests/test_e2e_12_mef_eline.py .....Xx..                                 [ 27%]
tests/test_e2e_13_mef_eline.py .......................ssss.............. [ 41%]
.                                                                        [ 41%]
tests/test_e2e_14_mef_eline.py ......                                    [ 43%]
tests/test_e2e_15_mef_eline.py ......                                    [ 45%]
tests/test_e2e_16_mef_eline.py ..                                        [ 45%]
tests/test_e2e_17_mef_eline.py .....                                     [ 47%]
tests/test_e2e_18_mef_eline.py .......                                   [ 49%]
tests/test_e2e_20_flow_manager.py .............................          [ 59%]
tests/test_e2e_21_flow_manager.py ...                                    [ 60%]
tests/test_e2e_22_flow_manager.py ...............                        [ 65%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ......                                      [ 71%]
tests/test_e2e_31_of_lldp.py ....                                        [ 72%]
tests/test_e2e_32_of_lldp.py ...                                         [ 73%]
tests/test_e2e_40_sdntrace.py ................                           [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ...............................         [ 92%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py .........                               [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [ 99%]
tests/test_e2e_90_kafka_events.py .                                      [ 99%]
tests/test_e2e_95_telemtry_int.py s                                      [100%]
=============================== warnings summary ===============================
tests/test_e2e_01_kytos_startup.py: 17 warnings
------------------------------- start/stop times -------------------------------
= 297 passed, 9 skipped, 2 xfailed, 1 xpassed, 1394 warnings in 15914.09s (4:25:14) =
```