### PR TITLE
[release 2025.2.1] fix: introduced `settings.RESULTS_QUEUE_MAX_SIZE=1000` to avoid unbounded trace results growth (mem leak related)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,15 @@ All notable changes to the sdntrace NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2025.2.1] - 2026-07-20
+***********************
+
+=======
+Changed
+=======
+- Added the trace timeout config into ``settings.py`` (which can still be overwritten from Trace request payload)
+- Introduced ``settings.RESULTS_QUEUE_MAX_SIZE=1000`` to avoid unbounded trace results growth
+
 [2025.2.0] - 2026-02-02
 ***********************
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,6 @@ All notable changes to the sdntrace NApp will be documented in this file.
 =======
 Changed
 =======
-- Added the trace timeout config into ``settings.py`` (which can still be overwritten from Trace request payload)
 - Introduced ``settings.RESULTS_QUEUE_MAX_SIZE=1000`` to avoid unbounded trace results growth
 
 [2025.2.0] - 2026-02-02

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "amlight",
   "name": "sdntrace",
   "description": "An OpenFlow Data Path Tracing",
-  "version": "2025.2.0",
+  "version": "2025.2.1",
   "napp_dependencies": ["amlight/coloring", "kytos/of_core"],
   "license": "GPL3.0",
   "tags": ["experimental", "coloring"],

--- a/settings.py
+++ b/settings.py
@@ -15,3 +15,9 @@ PARALLEL_TRACES = 10
 
 # URL for coloring app
 COLORS_URL = "http://localhost:8181/api/amlight/coloring/colors"
+
+# Timeout to wait for packet-in
+TIMEOUT = 0.5
+
+# Maximum number of finished trace results kept in memory
+RESULTS_QUEUE_MAX_SIZE = 1000

--- a/settings.py
+++ b/settings.py
@@ -16,8 +16,5 @@ PARALLEL_TRACES = 10
 # URL for coloring app
 COLORS_URL = "http://localhost:8181/api/amlight/coloring/colors"
 
-# Timeout to wait for packet-in
-TIMEOUT = 0.5
-
 # Maximum number of finished trace results kept in memory
 RESULTS_QUEUE_MAX_SIZE = 1000

--- a/tests/unit/tracing/test_trace_manager.py
+++ b/tests/unit/tracing/test_trace_manager.py
@@ -164,6 +164,16 @@ class TestTraceManager:
         trace_id = self.trace_manager.get_id()
         assert trace_id == 30003
 
+    def test_add_result_evicts_oldest_when_over_max(self):
+        """add_result keeps _results_queue bounded via FIFO eviction."""
+        self.trace_manager._results_queue.clear()
+        with patch.object(settings, "RESULTS_QUEUE_MAX_SIZE", 3):
+            for trace_id in range(5):
+                self.trace_manager.add_result(trace_id, {"result": trace_id})
+        # Only the newest 3 results are kept, oldest (0, 1) evicted in order.
+        assert len(self.trace_manager._results_queue) == 3
+        assert list(self.trace_manager._results_queue.keys()) == [2, 3, 4]
+
     @patch("napps.amlight.sdntrace.shared.colors.Colors.aget_switch_color")
     @patch("napps.amlight.sdntrace.tracing.tracer.TracePath.send_trace_probe")
     async def test_trace_pending(self, mock_send_probe, mock_acolors):
@@ -365,6 +375,7 @@ class TestTraceManagerTheadTest:
 
     def setup_method(self):
         """Set up before each test method"""
+        TestTraceManager.create_basic_switches(get_controller_mock())
         TraceManager.run_traces = MagicMock()
         self.trace_manager = TraceManager(controller=get_controller_mock())
         self.trace_manager.stop_traces()
@@ -399,9 +410,9 @@ class TestTraceManagerTheadTest:
         dpid = {"dpid": "00:00:00:00:00:00:00:01", "in_port": 1}
         switch = {"switch": dpid, "eth": eth}
         entries = {"trace": switch}
-        TraceEntries().load_entries(entries)
-
-        trace_entries = self.trace_manager._request_queue = Queue()
+        trace_entries = TraceEntries()
+        trace_entries.load_entries(entries)
+        self.trace_manager._request_queue = Queue()
         _ = await self.trace_manager.new_trace(trace_entries)
 
         trace_thread = threading.Thread(target=self.trace_manager._run_traces)

--- a/tests/unit/tracing/test_trace_manager.py
+++ b/tests/unit/tracing/test_trace_manager.py
@@ -167,10 +167,9 @@ class TestTraceManager:
     def test_add_result_evicts_oldest_when_over_max(self):
         """add_result keeps _results_queue bounded via FIFO eviction."""
         self.trace_manager._results_queue.clear()
-        with patch.object(settings, "RESULTS_QUEUE_MAX_SIZE", 3):
-            for trace_id in range(5):
-                self.trace_manager.add_result(trace_id, {"result": trace_id})
-        # Only the newest 3 results are kept, oldest (0, 1) evicted in order.
+        self.trace_manager._results_queue_max_size = 3
+        for trace_id in range(5):
+            self.trace_manager.add_result(trace_id, {"result": trace_id})
         assert len(self.trace_manager._results_queue) == 3
         assert list(self.trace_manager._results_queue.keys()) == [2, 3, 4]
 

--- a/tracing/trace_manager.py
+++ b/tracing/trace_manager.py
@@ -42,6 +42,7 @@ class TraceManager(object):
         self._request_queue = None
         self._results_queue = OrderedDict()
         self._running_traces:dict[int, TraceEntries] = dict()
+        self._results_queue_max_size = max(int(settings.RESULTS_QUEUE_MAX_SIZE), 1)
 
         # Counters
         self._total_traces_requested = 0
@@ -54,7 +55,7 @@ class TraceManager(object):
         self._async_loop = None
         # To start traces
         self.run_traces()
-
+    
     def stop_traces(self):
         if self._is_tracing_running:
             self._is_tracing_running = False
@@ -120,7 +121,10 @@ class TraceManager(object):
             result: trace result generated using tracer
         """
         self._results_queue[trace_id] = result
-        while len(self._results_queue) > settings.RESULTS_QUEUE_MAX_SIZE:
+        while (
+            self._results_queue
+            and len(self._results_queue) > self._results_queue_max_size
+        ):
             self._results_queue.popitem(last=False)
         self._running_traces.pop(trace_id, None)
 

--- a/tracing/trace_manager.py
+++ b/tracing/trace_manager.py
@@ -55,7 +55,7 @@ class TraceManager(object):
         self._async_loop = None
         # To start traces
         self.run_traces()
-    
+
     def stop_traces(self):
         if self._is_tracing_running:
             self._is_tracing_running = False

--- a/tracing/trace_manager.py
+++ b/tracing/trace_manager.py
@@ -7,7 +7,7 @@ import dill
 import time
 from janus import Queue
 from _thread import start_new_thread as new_thread
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from typing import Optional
 
 from kytos.core import log
@@ -40,7 +40,7 @@ class TraceManager(object):
         # Trace queues
         self._request_dict = dict()
         self._request_queue = None
-        self._results_queue = dict()
+        self._results_queue = OrderedDict()
         self._running_traces:dict[int, TraceEntries] = dict()
 
         # Counters
@@ -120,6 +120,8 @@ class TraceManager(object):
             result: trace result generated using tracer
         """
         self._results_queue[trace_id] = result
+        while len(self._results_queue) > settings.RESULTS_QUEUE_MAX_SIZE:
+            self._results_queue.popitem(last=False)
         self._running_traces.pop(trace_id, None)
 
     def avoid_duplicated_request(self, entries):


### PR DESCRIPTION
Backport of #122 
